### PR TITLE
Symfony 7 + PHP 8.2

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,21 +11,20 @@ jobs:
         timeout-minutes: 5
 
         steps:
-            -   uses: actions/checkout@v3.3.0
+            -   uses: actions/checkout@v4.1.6
             -   name: Composer cache
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 env:
                     cache-name: cache-composer
                 with:
                     path: ~/.cache/composer/
                     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./composer.json') }}
-                    restore-keys: |
-                        ${{ runner.os }}-build-${{ env.cache-name }}-
+                    restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
 
             -   name: Composer init
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.1'
+                    php-version: '8.2'
                     coverage: none
                     tools: composer:v2
 

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
 		}
 	},
 	"require": {
-		"php": ">=8.1",
-		"symfony/dependency-injection": "^6.2",
-		"symfony/config": "^6.2",
-		"symfony/yaml": "^6.2",
-		"symfony/finder": "^6.2"
+		"php": ">=8.2",
+		"symfony/dependency-injection": "^7.1",
+		"symfony/config": "^7.1",
+		"symfony/yaml": "^7.1",
+		"symfony/finder": "^7.1"
 	},
 	"require-dev": {
-		"phpstan/phpstan": "^1.9",
+		"phpstan/phpstan": "^1.11",
 		"phpunit/phpunit": "^10.0",
 		"symplify/easy-coding-standard": "^11.2"
 	},

--- a/src/Storage/FileStream.php
+++ b/src/Storage/FileStream.php
@@ -54,8 +54,8 @@ class FileStream implements Stream
      */
     public function read(int $length): string
     {
-        if ($length < 0) {
-            throw new InvalidArgumentException('`length` has to be non-negative integer.');
+        if ($length <= 0) {
+            throw new InvalidArgumentException('`length` has to be non-negative & non-zero integer.');
         }
 
         $data = @\fread($this->resource, $length);


### PR DESCRIPTION
In a Laravel 11 project - I attempted to use this project and got:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires phpwndb/phpwndb ^0.1.0 -> satisfiable by phpwndb/phpwndb[v0.1].
    - laravel/framework[v11.8.0, ..., v11.9.2] require symfony/finder ^7.0 -> satisfiable by symfony/finder[v7.0.0, v7.0.7, v7.0.8, v7.1.0].
    - You can only install one version of a package, so only one of these can be installed: symfony/finder[v4.3.4, ..., v4.4.44, v5.0.0, ..., v5.4.40, v6.0.0, ..., v6.4.8, v7.0.0, v7.0.7, v7.0.8, v7.1.0].
    - phpwndb/phpwndb v0.1 requires symfony/finder ^6.2 -> satisfiable by symfony/finder[v6.2.0, ..., v6.4.8].
```

So I jumped to PHP 8.2 (min on Symfony 7) as well as Symfony 7.